### PR TITLE
Fix Data.VirtualDOM.patch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-vdom",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "LGPL-3.0+",
   "repository": {
     "type": "git",

--- a/src/Data/VirtualDOM.purs
+++ b/src/Data/VirtualDOM.purs
@@ -175,6 +175,14 @@ patch api target old new = patchIndexed target old new 0
 
     walkChildren :: l → VNode e l v → VNode e l v → Eff e Unit
     walkChildren target (Element old) (Element new) = do
-      let r = 0 .. ((max (length old.children) (length new.children)) - 1)
-      sequence_ $ map (\i → patchIndexed target (old.children !! i) (new.children !! i) i) r
+        if (oldLength > newLength)
+          then do
+            walkIndexes (0 .. (newLength - 1)) -- walk up to last child of new
+            walkIndexes ((oldLength - 1) .. newLength) -- delete children backwards from end
+          else do
+            walkIndexes (0 .. (newLength - 1))
+      where
+        walkIndexes = sequence_ <<< map (\i → patchIndexed target (old.children !! i) (new.children !! i) i)
+        oldLength = length old.children
+        newLength = length new.children
     walkChildren _ _ _ = pure unit


### PR DESCRIPTION
If a VNode is modified to have fewer children 'patch' will leave
to-be-deleted nodes in the DOM. This happens because the indexes passed
to 'patchIndexed' become invalid after removing an element.

We can fix the problem by testing for this case and removing deleted
children in reverse order.